### PR TITLE
Fix arviz bug with pm.DensityDist

### DIFF
--- a/docs/source/notebooks/MLDA_benchmarks_tuning.ipynb
+++ b/docs/source/notebooks/MLDA_benchmarks_tuning.ipynb
@@ -231,9 +231,9 @@
     "            # convert m and c to a tensor vector\n",
     "            theta = tt.as_tensor_variable(parameters)\n",
     "\n",
-    "            # use a DensityDist (use a lamdba function to \"call\" the Op)\n",
+    "            # use a Potential for the likelihood\n",
     "            ll = logl[j]\n",
-    "            pm.DensityDist('likelihood', lambda v: ll(v), observed={'v': theta})\n",
+    "            pm.Potential('likelihood', ll(theta))\n",
     "\n",
     "        coarse_models.append(cmodel)\n",
     "      \n",
@@ -248,8 +248,8 @@
     "        # Convert m and c to a tensor vector\n",
     "        theta = tt.as_tensor_variable(parameters)\n",
     "\n",
-    "        # use a DensityDist (use a lamdba function to \"call\" the Op)\n",
-    "        pm.DensityDist('likelihood', lambda v: logl[-1](v), observed={'v': theta})\n",
+    "        ## use a Potential for the likelihood\n",
+    "        pm.Potential('likelihood', logl[-1](theta))\n",
     "        \n",
     "    return model, coarse_models, true_parameters"
    ]
@@ -2716,7 +2716,7 @@
    "source": [
     "Generally, the optimal subsampling rate depends on the complexity of the fine posterior. The more complex the posterior, the more samples are needed to generate a decent proposal. The reason is that the MLDA sampler is based on the assumption that the coarse proposal samples (i.e. the samples sent from the coarse chain to the fine one) are independent from each other. In order to generate independent samples, it is necessary to run the coarse chain for an adequate number of iterations to get rid of autocorrelation. The more complex the posterior the more iterations are needed and thus a larger subsampling rate.\n",
     "\n",
-    "Note that in cases where you have more than one coarse model/level, MLDA allows you to choose a different subsampling rate for each coarse level (as a list of integers when you instantiate the stepper)."    
+    "Note that in cases where you have more than one coarse model/level, MLDA allows you to choose a different subsampling rate for each coarse level (as a list of integers when you instantiate the stepper)."
    ]
   }
  ],

--- a/docs/source/notebooks/MLDA_multilevel_groundwater_flow.ipynb
+++ b/docs/source/notebooks/MLDA_multilevel_groundwater_flow.ipynb
@@ -352,9 +352,9 @@
     "        # convert m and c to a tensor vector\n",
     "        theta = tt.as_tensor_variable(parameters)\n",
     "\n",
-    "        # use a DensityDist (use a lamdba function to \"call\" the Op)\n",
+    "        # use a Potential for the likelihood\n",
     "        ll = logl[j]\n",
-    "        pm.DensityDist('likelihood', lambda v: ll(v), observed={'v': theta})\n",
+    "        pm.Potential('likelihood', ll(theta))\n",
     "\n",
     "    coarse_models.append(model)\n"
    ]
@@ -599,8 +599,8 @@
     "    # Convert m and c to a tensor vector\n",
     "    theta = tt.as_tensor_variable(parameters)\n",
     "\n",
-    "    # use a DensityDist (use a lamdba function to \"call\" the Op)\n",
-    "    pm.DensityDist('likelihood', lambda v: logl[-1](v), observed={'v': theta})\n",
+    "    # use a Potential for the likelihood\n",
+    "    pm.Potential('likelihood', logl[-1](theta))\n",
     "\n",
     "    # Initialise an MLDA step method object, passing the subsampling rate and\n",
     "    # coarse models list\n",

--- a/docs/source/notebooks/MLDA_multilevel_groundwater_flow_blocked.ipynb
+++ b/docs/source/notebooks/MLDA_multilevel_groundwater_flow_blocked.ipynb
@@ -352,9 +352,9 @@
     "        # convert m and c to a tensor vector\n",
     "        theta = tt.as_tensor_variable(parameters)\n",
     "\n",
-    "        # use a DensityDist (use a lamdba function to \"call\" the Op)\n",
+    "        # use a Potential for the likelihood\n",
     "        ll = logl[j]\n",
-    "        pm.DensityDist('likelihood', lambda v: ll(v), observed={'v': theta})\n",
+    "        pm.Potential('likelihood', ll(theta))\n",
     "\n",
     "    coarse_models.append(model)\n"
    ]
@@ -557,8 +557,8 @@
     "    # Convert m and c to a tensor vector\n",
     "    theta = tt.as_tensor_variable(parameters)\n",
     "\n",
-    "    # use a DensityDist (use a lamdba function to \"call\" the Op)\n",
-    "    pm.DensityDist('likelihood', lambda v: logl[-1](v), observed={'v': theta})\n",
+    "    # use a Potential for the likelihood\n",
+    "    pm.Potential('likelihood', logl[-1](theta))\n",
     "\n",
     "    # Initialise an MLDA step method object, passing the subsampling rate and\n",
     "    # coarse models list\n",

--- a/docs/source/notebooks/mlda/MLDA_multilevel_groundwater_flow.py
+++ b/docs/source/notebooks/mlda/MLDA_multilevel_groundwater_flow.py
@@ -113,16 +113,16 @@ resolutions = [(30, 30), (120, 120)]
 # Set random field parameters
 field_mean = 0
 field_stdev = 1
-lamb_cov = 0.1
+lamb_cov = 0.05
 
 # Set the number of unknown parameters (i.e. dimension of theta in posterior)
 nparam = 3
 
 # Number of draws from the distribution
-ndraws = 1000
+ndraws = 6000
 
 # Number of burn-in samples
-nburn = 500
+nburn = 6000
 
 # MLDA and Metropolis tuning parameters
 tune = True
@@ -130,7 +130,7 @@ tune_interval = 100
 discard_tuning = True
 
 # Number of independent chains
-nchains = 2
+nchains = 4
 
 # Subsampling rate for MLDA
 nsub = 5
@@ -273,9 +273,9 @@ for j in range(len(my_models) - 1):
         # convert m and c to a tensor vector
         theta = tt.as_tensor_variable(parameters)
 
-        # use a DensityDist (use a lamdba function to "call" the Op)
+        # use a Potential for the likelihood
         temp = logl[j]
-        pm.DensityDist('likelihood', lambda v, ll=temp: ll(v), observed={'v': theta})
+        pm.Potential('likelihood', temp(theta))
 
     coarse_models.append(model)
 
@@ -300,8 +300,8 @@ with pm.Model():
     # Convert m and c to a tensor vector
     theta = tt.as_tensor_variable(parameters)
 
-    # use a DensityDist (use a lamdba function to "call" the Op)
-    pm.DensityDist('likelihood', lambda v: logl[-1](v), observed={'v': theta})
+    # use a Potential for the likelihood
+    pm.Potential('likelihood', logl[-1](theta))
 
     # Initialise an MLDA step method object, passing the subsampling rate and
     # coarse models list


### PR DESCRIPTION
- Switches from pm.DensityDist to pm.Potential to describe the likelihood in MLDA notebooks and script examples. This is done because of the bug described [here](https://github.com/arviz-devs/arviz/issues/1279). 
- Changes a few parameters in the MLDA .py example to match the ones in the equivalent notebook.

Closes #40 
