### PR TITLE
Level renaming

### DIFF
--- a/pymc3/step_methods/mlda.py
+++ b/pymc3/step_methods/mlda.py
@@ -382,27 +382,31 @@ class MLDA(ArrayStepShared):
         self.is_child = kwargs.get("is_child", False)
         if not self.is_child:
             warnings.warn(
-                'The MLDA implementation in PyMC3 is very young. '
-                'You should be extra critical about its results.'
+                'The MLDA implementation in PyMC3 is still immature. You should be particularly critical of its results.'
             )
 
-        model = pm.modelcontext(model)
-
-        # assign internal state
-        self.coarse_models = coarse_models
         if not isinstance(coarse_models, list):
             raise ValueError(
                 "MLDA step method cannot use coarse_models if it is not a list"
             )
-        if len(self.coarse_models) == 0:
+        if len(coarse_models) == 0:
             raise ValueError(
                 "MLDA step method was given an empty "
                 "list of coarse models. Give at least "
                 "one coarse model."
             )
+        
+        # assign internal state
+        model = pm.modelcontext(model)
         self.model = model
+        self.coarse_models = coarse_models
+        self.model_below = self.coarse_models[-1]
+        self.num_levels = len(self.coarse_models) + 1
+        
+        # set up variance reduction.
         self.variance_reduction = variance_reduction
         self.store_Q_fine = store_Q_fine
+        
         # check that certain requirements hold
         # for the variance reduction feature to work
         if self.variance_reduction or self.store_Q_fine:
@@ -417,9 +421,15 @@ class MLDA(ArrayStepShared):
                 raise TypeError("The variable 'Q' in the model definition is not of type "
                                 "'TensorSharedVariable'. Use pm.Data() to define the"
                                 "variable.")
-
-        self.model_below = self.coarse_models[-1]
+                                
+        if self.is_child and self.variance_reduction:
+            # this is the subsampling rate applied to the current level
+            # it is stored in the level above and transferred here
+            self.subsampling_rate_above = kwargs.pop("subsampling_rate_above", None)
+        
+        # set up adaptive error model
         self.adaptive_error_model = adaptive_error_model
+        
         # check that certain requirements hold
         # for the adaptive error model feature to work
         if self.adaptive_error_model:
@@ -438,7 +448,7 @@ class MLDA(ArrayStepShared):
             if not (isinstance(self.model_below.mu_B, tt.sharedvar.TensorSharedVariable) and
                     isinstance(self.model_below.Sigma_B, tt.sharedvar.TensorSharedVariable)):
                 raise TypeError("At least one of the variables 'mu_B' and 'Sigma_B' "
-                                "in the model below's definition is not of type "
+                                "in the definition of the below model is not of type "
                                 "'TensorSharedVariable'. Use pm.Data() to define those "
                                 "variables.")
 
@@ -460,7 +470,8 @@ class MLDA(ArrayStepShared):
             # variables used for adaptive error model
             self.last_synced_output_diff = None
             self.adaptation_started = False
-
+        
+        # set up subsampling rates.
         if isinstance(subsampling_rates, int):
             self.subsampling_rates = [subsampling_rates] * len(self.coarse_models)
         else:
@@ -471,14 +482,11 @@ class MLDA(ArrayStepShared):
                     f"were {len(subsampling_rates)}, {len(self.coarse_models)}"
                 )
             self.subsampling_rates = subsampling_rates
+        
         self.subsampling_rate = self.subsampling_rates[-1]
         self.subchain_selection = None
-        if self.is_child and self.variance_reduction:
-            # this is the subsampling rate applied to the current level
-            # it is stored in the level above and transferred here
-            self.subsampling_rate_above = kwargs.pop("subsampling_rate_above", None)
 
-        self.num_levels = len(self.coarse_models) + 1
+        # set up base sampling
         self.base_sampler = base_sampler
 
         # VR is not compatible with compound base samplers so an automatic conversion
@@ -491,7 +499,7 @@ class MLDA(ArrayStepShared):
             self.base_blocked = True
         else:
             self.base_blocked = base_blocked
-        self.model_below = self.coarse_models[-1]
+
         self.base_S = base_S
         self.base_proposal_dist = base_proposal_dist
 
@@ -513,8 +521,10 @@ class MLDA(ArrayStepShared):
         self.base_tune_interval = base_tune_interval
         self.base_lamb = base_lamb
         self.base_tune_drop_fraction = float(base_tune_drop_fraction)
-        self.mode = mode
         self.base_scaling_stats = None
+        
+        self.mode = mode
+        
         if self.base_sampler == 'DEMetropolisZ':
             self.base_lambda_stats = None
 
@@ -539,7 +549,7 @@ class MLDA(ArrayStepShared):
         vars_below = pm.inputvars(vars_below)
         shared_below = pm.make_shared_replacements(vars_below, model_below)
         self.delta_logp_below = delta_logp(model_below.logpt, vars_below, shared_below)
-        self.model = model
+        
         super().__init__(vars, shared)
 
         # initialise complete step method hierarchy
@@ -560,31 +570,32 @@ class MLDA(ArrayStepShared):
                 if self.base_sampler == 'Metropolis':
                     # MetropolisMLDA sampler in base level (level=0), targeting self.model_below
                     self.step_method_below = pm.MetropolisMLDA(vars=vars_below,
-                                                              proposal_dist=self.base_proposal_dist,
-                                                              S=self.base_S,
-                                                              scaling=self.base_scaling, tune=self.tune,
-                                                              tune_interval=self.base_tune_interval,
-                                                              model=None,
-                                                              mode=self.mode,
-                                                              blocked=self.base_blocked,
-                                                              ** base_kwargs)
+                                                               proposal_dist=self.base_proposal_dist,
+                                                               S=self.base_S,
+                                                               scaling=self.base_scaling, tune=self.tune,
+                                                               tune_interval=self.base_tune_interval,
+                                                               model=None,
+                                                               mode=self.mode,
+                                                               blocked=self.base_blocked,
+                                                               ** base_kwargs)
                 else:
                     # DEMetropolisZMLDA sampler in base level (level=0), targeting self.model_below
                     self.step_method_below = pm.DEMetropolisZMLDA(vars=vars_below,
-                                                                 S=self.base_S,
-                                                                 proposal_dist=self.base_proposal_dist,
-                                                                 lamb=self.base_lamb,
-                                                                 scaling=self.base_scaling,
-                                                                 tune=self.base_tune_target,
-                                                                 tune_interval=self.base_tune_interval,
-                                                                 tune_drop_fraction=self.base_tune_drop_fraction,
-                                                                 model=None,
-                                                                 mode=self.mode,
-                                                                 ** base_kwargs)
+                                                                  S=self.base_S,
+                                                                  proposal_dist=self.base_proposal_dist,
+                                                                  lamb=self.base_lamb,
+                                                                  scaling=self.base_scaling,
+                                                                  tune=self.base_tune_target,
+                                                                  tune_interval=self.base_tune_interval,
+                                                                  tune_drop_fraction=self.base_tune_drop_fraction,
+                                                                  model=None,
+                                                                  mode=self.mode,
+                                                                  ** base_kwargs)
         else:
             # drop the last coarse model
             coarse_models_below = self.coarse_models[:-1]
             subsampling_rates_below = self.subsampling_rates[:-1]
+            
             with self.model_below:
                 # make sure the correct variables are selected from model_below
                 vars_below = [
@@ -602,22 +613,22 @@ class MLDA(ArrayStepShared):
 
                 # MLDA sampler in some intermediate level, targeting self.model_below
                 self.step_method_below = pm.MLDA(vars=vars_below, base_S=self.base_S,
-                                                base_sampler=self.base_sampler,
-                                                base_proposal_dist=self.base_proposal_dist,
-                                                base_scaling=self.base_scaling,
-                                                tune=self.tune,
-                                                base_tune_target=self.base_tune_target,
-                                                base_tune_interval=self.base_tune_interval,
-                                                base_lamb=self.base_lamb,
-                                                base_tune_drop_fraction=self.base_tune_drop_fraction,
-                                                model=None, mode=self.mode,
-                                                subsampling_rates=subsampling_rates_below,
-                                                coarse_models=coarse_models_below,
-                                                base_blocked=self.base_blocked,
-                                                variance_reduction=self.variance_reduction,
-                                                store_Q_fine=False,
-                                                adaptive_error_model=self.adaptive_error_model,
-                                                **mlda_kwargs)
+                                                 base_sampler=self.base_sampler,
+                                                 base_proposal_dist=self.base_proposal_dist,
+                                                 base_scaling=self.base_scaling,
+                                                 tune=self.tune,
+                                                 base_tune_target=self.base_tune_target,
+                                                 base_tune_interval=self.base_tune_interval,
+                                                 base_lamb=self.base_lamb,
+                                                 base_tune_drop_fraction=self.base_tune_drop_fraction,
+                                                 model=None, mode=self.mode,
+                                                 subsampling_rates=subsampling_rates_below,
+                                                 coarse_models=coarse_models_below,
+                                                 base_blocked=self.base_blocked,
+                                                 variance_reduction=self.variance_reduction,
+                                                 store_Q_fine=False,
+                                                 adaptive_error_model=self.adaptive_error_model,
+                                                 **mlda_kwargs)
 
         # instantiate the recursive DA proposal.
         # this is the main proposal used for

--- a/pymc3/step_methods/mlda.py
+++ b/pymc3/step_methods/mlda.py
@@ -418,35 +418,35 @@ class MLDA(ArrayStepShared):
                                 "'TensorSharedVariable'. Use pm.Data() to define the"
                                 "variable.")
 
-        self.next_model = self.coarse_models[-1]
+        self.model_below = self.coarse_models[-1]
         self.adaptive_error_model = adaptive_error_model
         # check that certain requirements hold
         # for the adaptive error model feature to work
         if self.adaptive_error_model:
-            if not hasattr(self.next_model, 'mu_B'):
-                raise AttributeError("Next model in hierarchy does not contain"
+            if not hasattr(self.model_below, 'mu_B'):
+                raise AttributeError("Model below in hierarchy does not contain"
                                      "variable 'mu_B'. You need to include"
                                      "the variable in the model definition"
                                      "for adaptive error model to work."
                                      "Use pm.Data() to define it.")
-            if not hasattr(self.next_model, 'Sigma_B'):
-                raise AttributeError("Next model in hierarchy does not contain"
+            if not hasattr(self.model_below, 'Sigma_B'):
+                raise AttributeError("Model below in hierarchy does not contain"
                                      "variable 'Sigma_B'. You need to include"
                                      "the variable in the model definition"
                                      "for adaptive error model to work."
                                      "Use pm.Data() to define it.")
-            if not (isinstance(self.next_model.mu_B, tt.sharedvar.TensorSharedVariable) and
-                    isinstance(self.next_model.Sigma_B, tt.sharedvar.TensorSharedVariable)):
+            if not (isinstance(self.model_below.mu_B, tt.sharedvar.TensorSharedVariable) and
+                    isinstance(self.model_below.Sigma_B, tt.sharedvar.TensorSharedVariable)):
                 raise TypeError("At least one of the variables 'mu_B' and 'Sigma_B' "
-                                "in the next model's definition is not of type "
+                                "in the model below's definition is not of type "
                                 "'TensorSharedVariable'. Use pm.Data() to define those "
                                 "variables.")
 
             # this object is used to recursively update the mean and
             # variance of the bias correction given new differences
             # between levels
-            self.bias = RecursiveSampleMoments(self.next_model.mu_B.get_value(),
-                                               self.next_model.Sigma_B.get_value())
+            self.bias = RecursiveSampleMoments(self.model_below.mu_B.get_value(),
+                                               self.model_below.Sigma_B.get_value())
 
             # this list holds the bias objects from all levels
             # it is gradually constructed when MLDA objects are
@@ -491,7 +491,7 @@ class MLDA(ArrayStepShared):
             self.base_blocked = True
         else:
             self.base_blocked = base_blocked
-        self.next_model = self.coarse_models[-1]
+        self.model_below = self.coarse_models[-1]
         self.base_S = base_S
         self.base_proposal_dist = base_proposal_dist
 
@@ -532,22 +532,22 @@ class MLDA(ArrayStepShared):
         shared = pm.make_shared_replacements(vars, model)
         self.delta_logp = delta_logp_inverse(model.logpt, vars, shared)
 
-        # Construct theano function for next-level model likelihood
+        # Construct theano function for below-level model likelihood
         # (for use in acceptance)
-        next_model = pm.modelcontext(self.next_model)
-        vars_next = [var for var in next_model.vars if var.name in self.var_names]
-        vars_next = pm.inputvars(vars_next)
-        shared_next = pm.make_shared_replacements(vars_next, next_model)
-        self.delta_logp_next = delta_logp(next_model.logpt, vars_next, shared_next)
+        model_below = pm.modelcontext(self.model_below)
+        vars_below = [var for var in model_below.vars if var.name in self.var_names]
+        vars_below = pm.inputvars(vars_below)
+        shared_below = pm.make_shared_replacements(vars_below, model_below)
+        self.delta_logp_below = delta_logp(model_below.logpt, vars_below, shared_below)
         self.model = model
         super().__init__(vars, shared)
 
         # initialise complete step method hierarchy
         if self.num_levels == 2:
-            with self.next_model:
-                # make sure the correct variables are selected from next_model
-                vars_next = [
-                    var for var in self.next_model.vars if var.name in self.var_names
+            with self.model_below:
+                # make sure the correct variables are selected from model_below
+                vars_below = [
+                    var for var in self.model_below.vars if var.name in self.var_names
                 ]
 
                 # create kwargs
@@ -558,8 +558,8 @@ class MLDA(ArrayStepShared):
                     base_kwargs = {}
 
                 if self.base_sampler == 'Metropolis':
-                    # MetropolisMLDA sampler in base level (level=0), targeting self.next_model
-                    self.next_step_method = pm.MetropolisMLDA(vars=vars_next,
+                    # MetropolisMLDA sampler in base level (level=0), targeting self.model_below
+                    self.step_method_below = pm.MetropolisMLDA(vars=vars_below,
                                                               proposal_dist=self.base_proposal_dist,
                                                               S=self.base_S,
                                                               scaling=self.base_scaling, tune=self.tune,
@@ -569,8 +569,8 @@ class MLDA(ArrayStepShared):
                                                               blocked=self.base_blocked,
                                                               ** base_kwargs)
                 else:
-                    # DEMetropolisZMLDA sampler in base level (level=0), targeting self.next_model
-                    self.next_step_method = pm.DEMetropolisZMLDA(vars=vars_next,
+                    # DEMetropolisZMLDA sampler in base level (level=0), targeting self.model_below
+                    self.step_method_below = pm.DEMetropolisZMLDA(vars=vars_below,
                                                                  S=self.base_S,
                                                                  proposal_dist=self.base_proposal_dist,
                                                                  lamb=self.base_lamb,
@@ -583,12 +583,12 @@ class MLDA(ArrayStepShared):
                                                                  ** base_kwargs)
         else:
             # drop the last coarse model
-            next_coarse_models = self.coarse_models[:-1]
-            next_subsampling_rates = self.subsampling_rates[:-1]
-            with self.next_model:
-                # make sure the correct variables are selected from next_model
-                vars_next = [
-                    var for var in self.next_model.vars if var.name in self.var_names
+            coarse_models_below = self.coarse_models[:-1]
+            subsampling_rates_below = self.subsampling_rates[:-1]
+            with self.model_below:
+                # make sure the correct variables are selected from model_below
+                vars_below = [
+                    var for var in self.model_below.vars if var.name in self.var_names
                 ]
 
                 # create kwargs
@@ -600,8 +600,8 @@ class MLDA(ArrayStepShared):
                 if self.adaptive_error_model:
                     mlda_kwargs = {**mlda_kwargs, **{"bias_all": self.bias_all}}
 
-                # MLDA sampler in some intermediate level, targeting self.next_model
-                self.next_step_method = pm.MLDA(vars=vars_next, base_S=self.base_S,
+                # MLDA sampler in some intermediate level, targeting self.model_below
+                self.step_method_below = pm.MLDA(vars=vars_below, base_S=self.base_S,
                                                 base_sampler=self.base_sampler,
                                                 base_proposal_dist=self.base_proposal_dist,
                                                 base_scaling=self.base_scaling,
@@ -611,8 +611,8 @@ class MLDA(ArrayStepShared):
                                                 base_lamb=self.base_lamb,
                                                 base_tune_drop_fraction=self.base_tune_drop_fraction,
                                                 model=None, mode=self.mode,
-                                                subsampling_rates=next_subsampling_rates,
-                                                coarse_models=next_coarse_models,
+                                                subsampling_rates=subsampling_rates_below,
+                                                coarse_models=coarse_models_below,
                                                 base_blocked=self.base_blocked,
                                                 variance_reduction=self.variance_reduction,
                                                 store_Q_fine=False,
@@ -625,8 +625,8 @@ class MLDA(ArrayStepShared):
         # (except for level 0 where the step method is MetropolisMLDA
         # or DEMetropolisZMLDA - not MLDA)
         self.proposal_dist = RecursiveDAProposal(
-            self.next_step_method,
-            self.next_model,
+            self.step_method_below,
+            self.model_below,
             self.tune,
             self.subsampling_rate
         )
@@ -665,8 +665,8 @@ class MLDA(ArrayStepShared):
             self.proposal_dist.tune = self.tune
             # set tune in sub-methods of compound stepper explicitly because
             # it is not set within sample.py (only the CompoundStep's tune flag is)
-            if isinstance(self.next_step_method, CompoundStep):
-                for method in self.next_step_method.methods:
+            if isinstance(self.step_method_below, CompoundStep):
+                for method in self.step_method_below.methods:
                     method.tune = self.tune
             self.accepted = 0
 
@@ -696,7 +696,7 @@ class MLDA(ArrayStepShared):
             accept = np.float(0.0)
             skipped_logp = True
         else:
-            accept = self.delta_logp(q, q0) + self.delta_logp_next(q0, q)
+            accept = self.delta_logp(q, q0) + self.delta_logp_below(q0, q)
             skipped_logp = False
 
         # Accept/reject sample - next sample is stored in q_new
@@ -716,30 +716,30 @@ class MLDA(ArrayStepShared):
 
         stats = {"tune": self.tune, "accept": np.exp(accept), "accepted": accepted}
 
-        # Capture latest base chain scaling stats from next step method
+        # Capture latest base chain scaling stats from below step method
         self.base_scaling_stats = {}
         if self.base_sampler == "DEMetropolisZ":
             self.base_lambda_stats = {}
-        if isinstance(self.next_step_method, CompoundStep):
-            # next method is Compound MetropolisMLDA
+        if isinstance(self.step_method_below, CompoundStep):
+            # below method is Compound MetropolisMLDA
             scaling_list = []
-            for method in self.next_step_method.methods:
+            for method in self.step_method_below.methods:
                 scaling_list.append(method.scaling)
             self.base_scaling_stats = {"base_scaling": np.array(scaling_list)}
-        elif not isinstance(self.next_step_method, MLDA):
-            # next method is any block sampler
+        elif not isinstance(self.step_method_below, MLDA):
+            # below method is any block sampler
             self.base_scaling_stats = {
-                "base_scaling": np.array(self.next_step_method.scaling)
+                "base_scaling": np.array(self.step_method_below.scaling)
             }
             if self.base_sampler == "DEMetropolisZ":
                 self.base_lambda_stats = {
-                    "base_lambda": self.next_step_method.lamb
+                    "base_lambda": self.step_method_below.lamb
                 }
         else:
-            # next method is MLDA - propagate dict from lower levels
-            self.base_scaling_stats = self.next_step_method.base_scaling_stats
+            # below method is MLDA - propagate dict from lower levels
+            self.base_scaling_stats = self.step_method_below.base_scaling_stats
             if self.base_sampler == "DEMetropolisZ":
-                self.base_lambda_stats = self.next_step_method.base_lambda_stats
+                self.base_lambda_stats = self.step_method_below.base_lambda_stats
         stats = {**stats, **self.base_scaling_stats}
         if self.base_sampler == "DEMetropolisZ":
             stats = {**stats, **self.base_lambda_stats}
@@ -758,7 +758,7 @@ class MLDA(ArrayStepShared):
                     m.Q_diff = []
                     if level == 1:
                         break
-                    m = m.next_step_method
+                    m = m.step_method_below
                 q_stats['Q_0'] = np.array(m.Q_base_full)
                 m.Q_base_full = []
             if self.store_Q_fine:
@@ -799,7 +799,7 @@ class MLDA(ArrayStepShared):
             # and add them to Q_base_full (which stores all the history of
             # Q values from the base level)
             if self.num_levels == 2:
-                self.Q_base_full.extend(self.next_step_method.Q_reg)
+                self.Q_base_full.extend(self.step_method_below.Q_reg)
 
             # if the sample is accepted, update Q_diff_last with the latest
             # difference between the last Q of this level and the Q of the
@@ -807,7 +807,7 @@ class MLDA(ArrayStepShared):
             # If sample is not accepted, just keep the latest accepted Q_diff
             if accepted and not skipped_logp:
                 self.Q_diff_last = self.Q_last -\
-                                   self.next_step_method.Q_reg[self.subchain_selection]
+                                   self.step_method_below.Q_reg[self.subchain_selection]
             # Add the last accepted Q_diff to the list
             self.Q_diff.append(self.Q_diff_last)
 
@@ -824,7 +824,7 @@ class MLDA(ArrayStepShared):
             # this is the error (i.e. forward model output difference)
             # between the current level's model and the model in the level below
             self.last_synced_output_diff = self.model.model_output.get_value() - \
-                                           self.next_model.model_output.get_value()
+                                           self.model_below.model_output.get_value()
             self.adaptation_started = True
         if self.adaptation_started:
             # update the internal recursive bias estimator with the last saved error
@@ -835,7 +835,7 @@ class MLDA(ArrayStepShared):
             # The model variables mu_B and Signa_B of a level are the
             # sum of the bias corrections of all levels below and including
             # that level. This sum is updated here.
-            with self.next_model:
+            with self.model_below:
                 pm.set_data({'mu_B': sum([bias.get_mu() for bias in
                                           self.bias_all[:len(self.bias_all) - self.num_levels + 2]])})
                 pm.set_data({'Sigma_B': sum([bias.get_sigma() for bias in
@@ -999,13 +999,13 @@ class RecursiveDAProposal(Proposal):
     """
 
     def __init__(self,
-                 next_step_method: Union[MLDA, MetropolisMLDA, DEMetropolisZMLDA, CompoundStep],
-                 next_model: Model,
+                 step_method_below: Union[MLDA, MetropolisMLDA, DEMetropolisZMLDA, CompoundStep],
+                 model_below: Model,
                  tune: bool,
                  subsampling_rate: int) -> None:
 
-        self.next_step_method = next_step_method
-        self.next_model = next_model
+        self.step_method_below = step_method_below
+        self.model_below = model_below
         self.tune = tune
         self.subsampling_rate = subsampling_rate
         self.subchain_selection = None
@@ -1022,7 +1022,7 @@ class RecursiveDAProposal(Proposal):
         _log = logging.getLogger("pymc3")
         _log.setLevel(logging.ERROR)
 
-        with self.next_model:
+        with self.model_below:
             # Check if the tuning flag has been set to False
             # in which case tuning is stopped. The flag is set
             # to False (by MLDA's astep) when the burn-in
@@ -1031,7 +1031,7 @@ class RecursiveDAProposal(Proposal):
             
             if self.tune:
                 # Subsample in tuning mode
-                self.trace = subsample(draws=0, step=self.next_step_method,
+                self.trace = subsample(draws=0, step=self.step_method_below,
                                        start=q0_dict, trace=self.trace,
                                        tune=self.subsampling_rate)
             else:
@@ -1039,12 +1039,12 @@ class RecursiveDAProposal(Proposal):
                 # If DEMetropolisZMLDA is the base sampler a flag is raised to
                 # make sure that history is edited after tuning ends
                 if self.tuning_end_trigger:
-                    if isinstance(self.next_step_method, DEMetropolisZMLDA):
-                        self.next_step_method.tuning_end_trigger = True
+                    if isinstance(self.step_method_below, DEMetropolisZMLDA):
+                        self.step_method_below.tuning_end_trigger = True
                     self.tuning_end_trigger = False
                 
                 self.trace = subsample(draws=self.subsampling_rate,
-                                       step=self.next_step_method,
+                                       step=self.step_method_below,
                                        start=q0_dict, trace=self.trace)
 
         # set logging back to normal

--- a/pymc3/step_methods/mlda.py
+++ b/pymc3/step_methods/mlda.py
@@ -703,9 +703,16 @@ class MLDA(ArrayStepShared):
         q_new, accepted = metrop_select(accept, q, q0)
         if skipped_logp:
             accepted = False
+            
+        # if sample is accepted, update self.Q_last with the sample's Q value
+        # runs only for VR or when store_Q_fine is True
+        if self.variance_reduction or self.store_Q_fine:
+            if accepted and not skipped_logp:
+                self.Q_last = self.model.Q.get_value()
 
         # Variance reduction
-        self.update_vr_variables(accepted, skipped_logp)
+        if self.variance_reduction:
+            self.update_vr_variables(accepted, skipped_logp)
 
         # Adaptive error model - runs only during tuning.
         if self.tune and self.adaptive_error_model:
@@ -777,39 +784,32 @@ class MLDA(ArrayStepShared):
 
         These registers are updated here so that they can be exported later."""
 
-        # if sample is accepted, update self.Q_last with the sample's Q value
-        # runs only for VR or when store_Q_fine is True
-        if self.variance_reduction or self.store_Q_fine:
-            if accepted and not skipped_logp:
-                self.Q_last = self.model.Q.get_value()
+        # if this MLDA is not at the finest level, store Q_last in a
+        # register Q_reg and increase sub_counter (until you reach
+        # the subsampling rate, at which point you make it zero).
+        # Q_reg will later be used by the level above to calculate differences
+        if self.is_child:
+            if self.sub_counter == self.subsampling_rate_above:
+                self.sub_counter = 0
+            self.Q_reg[self.sub_counter] = self.Q_last
+            self.sub_counter += 1
 
-        if self.variance_reduction:
-            # if this MLDA is not at the finest level, store Q_last in a
-            # register Q_reg and increase sub_counter (until you reach
-            # the subsampling rate, at which point you make it zero).
-            # Q_reg will later be used by the level above to calculate differences
-            if self.is_child:
-                if self.sub_counter == self.subsampling_rate_above:
-                    self.sub_counter = 0
-                self.Q_reg[self.sub_counter] = self.Q_last
-                self.sub_counter += 1
+        # if MLDA is in the level above the base level, extract the
+        # latest set of Q values from Q_reg in the base level
+        # and add them to Q_base_full (which stores all the history of
+        # Q values from the base level)
+        if self.num_levels == 2:
+            self.Q_base_full.extend(self.step_method_below.Q_reg)
 
-            # if MLDA is in the level above the base level, extract the
-            # latest set of Q values from Q_reg in the base level
-            # and add them to Q_base_full (which stores all the history of
-            # Q values from the base level)
-            if self.num_levels == 2:
-                self.Q_base_full.extend(self.step_method_below.Q_reg)
-
-            # if the sample is accepted, update Q_diff_last with the latest
-            # difference between the last Q of this level and the Q of the
-            # proposed (selected) sample from the level below.
-            # If sample is not accepted, just keep the latest accepted Q_diff
-            if accepted and not skipped_logp:
-                self.Q_diff_last = self.Q_last -\
-                                   self.step_method_below.Q_reg[self.subchain_selection]
-            # Add the last accepted Q_diff to the list
-            self.Q_diff.append(self.Q_diff_last)
+        # if the sample is accepted, update Q_diff_last with the latest
+        # difference between the last Q of this level and the Q of the
+        # proposed (selected) sample from the level below.
+        # If sample is not accepted, just keep the latest accepted Q_diff
+        if accepted and not skipped_logp:
+            self.Q_diff_last = self.Q_last -\
+                               self.step_method_below.Q_reg[self.subchain_selection]
+        # Add the last accepted Q_diff to the list
+        self.Q_diff.append(self.Q_diff_last)
 
     def update_error_estimate(self, accepted, skipped_logp):
         """Updates the adaptive error model estimate with
@@ -826,6 +826,7 @@ class MLDA(ArrayStepShared):
             self.last_synced_output_diff = self.model.model_output.get_value() - \
                                            self.model_below.model_output.get_value()
             self.adaptation_started = True
+        
         if self.adaptation_started:
             # update the internal recursive bias estimator with the last saved error
             self.bias.update(self.last_synced_output_diff)

--- a/pymc3/tests/test_step.py
+++ b/pymc3/tests/test_step.py
@@ -1041,13 +1041,13 @@ class TestMLDA:
             assert isinstance(sampler.proposal_dist,
                               RecursiveDAProposal)
             assert sampler.base_proposal_dist is None
-            assert isinstance(sampler.next_step_method.proposal_dist, NormalProposal)
+            assert isinstance(sampler.step_method_below.proposal_dist, NormalProposal)
 
             sampler = MLDA(coarse_models=[model_coarse])
             assert isinstance(sampler.proposal_dist,
                               RecursiveDAProposal)
             assert sampler.base_proposal_dist is None
-            assert isinstance(sampler.next_step_method.proposal_dist,
+            assert isinstance(sampler.step_method_below.proposal_dist,
                               UniformProposal)
 
             s = np.ones(model.ndim)
@@ -1056,14 +1056,14 @@ class TestMLDA:
             assert isinstance(sampler.proposal_dist,
                               RecursiveDAProposal)
             assert sampler.base_proposal_dist is None
-            assert isinstance(sampler.next_step_method.proposal_dist, NormalProposal)
+            assert isinstance(sampler.step_method_below.proposal_dist, NormalProposal)
 
             sampler = MLDA(coarse_models=[model_coarse],
                            base_S=s)
             assert isinstance(sampler.proposal_dist,
                               RecursiveDAProposal)
             assert sampler.base_proposal_dist is None
-            assert isinstance(sampler.next_step_method.proposal_dist,
+            assert isinstance(sampler.step_method_below.proposal_dist,
                               UniformProposal)
 
             s = np.diag(s)
@@ -1072,14 +1072,14 @@ class TestMLDA:
             assert isinstance(sampler.proposal_dist,
                               RecursiveDAProposal)
             assert sampler.base_proposal_dist is None
-            assert isinstance(sampler.next_step_method.proposal_dist, MultivariateNormalProposal)
+            assert isinstance(sampler.step_method_below.proposal_dist, MultivariateNormalProposal)
 
             sampler = MLDA(coarse_models=[model_coarse],
                            base_S=s)
             assert isinstance(sampler.proposal_dist,
                               RecursiveDAProposal)
             assert sampler.base_proposal_dist is None
-            assert isinstance(sampler.next_step_method.proposal_dist,
+            assert isinstance(sampler.step_method_below.proposal_dist,
                               UniformProposal)
 
             s[0, 0] = -s[0, 0]
@@ -1096,15 +1096,15 @@ class TestMLDA:
             s = np.ones(model.ndim) + 2.0
             sampler = MLDA(coarse_models=[model_very_coarse, model_coarse],
                            base_S=s, base_sampler='Metropolis')
-            assert isinstance(sampler.next_step_method, MLDA)
-            assert isinstance(sampler.next_step_method.next_step_method, Metropolis)
-            assert np.all(sampler.next_step_method.next_step_method.proposal_dist.s == s)
+            assert isinstance(sampler.step_method_below, MLDA)
+            assert isinstance(sampler.step_method_below.step_method_below, Metropolis)
+            assert np.all(sampler.step_method_below.step_method_below.proposal_dist.s == s)
 
             sampler = MLDA(coarse_models=[model_very_coarse, model_coarse],
                            base_S=s)
-            assert isinstance(sampler.next_step_method, MLDA)
-            assert isinstance(sampler.next_step_method.next_step_method, DEMetropolisZ)
-            assert np.all(sampler.next_step_method.next_step_method.proposal_dist.s == s)
+            assert isinstance(sampler.step_method_below, MLDA)
+            assert isinstance(sampler.step_method_below.step_method_below, DEMetropolisZ)
+            assert np.all(sampler.step_method_below.step_method_below.proposal_dist.s == s)
 
     def test_exceptions_coarse_models(self):
         """Test that MLDA generates the expected exceptions when no coarse_models arg
@@ -1197,7 +1197,7 @@ class TestMLDA:
             for stepper in self.steppers:
                 assert isinstance(stepper(coarse_models=[model_coarse],
                                           base_sampler='Metropolis',
-                                          base_blocked=False).next_step_method,
+                                          base_blocked=False).step_method_below,
                                   CompoundStep)
 
     def test_mlda_blocked(self):
@@ -1211,13 +1211,13 @@ class TestMLDA:
             for stepper in self.steppers:
                 assert not isinstance(stepper(coarse_models=[model_coarse],
                                               base_sampler='Metropolis',
-                                              base_blocked=True).next_step_method,
+                                              base_blocked=True).step_method_below,
                                       CompoundStep)
                 assert isinstance(stepper(coarse_models=[model_coarse],
                                           base_sampler='Metropolis',
-                                          base_blocked=True).next_step_method,
+                                          base_blocked=True).step_method_below,
                                   Metropolis)
-                assert isinstance(stepper(coarse_models=[model_coarse]).next_step_method,
+                assert isinstance(stepper(coarse_models=[model_coarse]).step_method_below,
                                   DEMetropolisZ)
 
     def test_tuning_and_scaling_on(self):
@@ -1526,10 +1526,10 @@ class TestMLDA:
                                 discard_tuned_samples=True,
                                 random_seed=84759238)
 
-            m0 = step_mlda.next_step_method.next_model.mu_B.get_value()
-            s0 = step_mlda.next_step_method.next_model.Sigma_B.get_value()
-            m1 = step_mlda.next_model.mu_B.get_value()
-            s1 = step_mlda.next_model.Sigma_B.get_value()
+            m0 = step_mlda.step_method_below.model_below.mu_B.get_value()
+            s0 = step_mlda.step_method_below.model_below.Sigma_B.get_value()
+            m1 = step_mlda.model_below.mu_B.get_value()
+            s1 = step_mlda.model_below.Sigma_B.get_value()
 
             assert np.all(np.abs(m0 + 3.5 * np.ones(y.shape, dtype=p)) < 1e-1)
             assert np.all(np.abs(m1 + 2.2 * np.ones(y.shape, dtype=p)) < 1e-1)


### PR DESCRIPTION
This is a minor reworking of the code:
* It changes the naming convention from `next_model` to `model_below` and `next_step_method` to `step_method_below`, to be more consistent with the nomenclature of the VR functionality.
* It slightly reorganises the way, VR is being triggered by the astep function, to be more consistent with the AEM trigger,
* It reorganises the code, and gets rid of duplicate assignments of `self.model` and `self.model_below` (previously `self.next_model`)

`test_step.py` has also been reworked to reflect the naming changes.